### PR TITLE
SystemUI: Allow snoozing SD card notification unconditionally

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
+++ b/packages/SystemUI/src/com/android/systemui/usb/StorageNotification.java
@@ -357,9 +357,8 @@ public class StorageNotification extends SystemUI {
         final VolumeRecord rec = mStorageManager.findRecordByUuid(vol.getFsUuid());
         final DiskInfo disk = vol.getDisk();
 
-        // Don't annoy when user dismissed in past.  (But make sure the disk is adoptable; we
-        // used to allow snoozing non-adoptable disks too.)
-        if (rec.isSnoozed() && disk.isAdoptable()) {
+        // Don't annoy when user dismissed in past.
+        if (rec.isSnoozed() && (disk.isAdoptable() || disk.isSd())) {
             return null;
         }
 
@@ -398,8 +397,7 @@ public class StorageNotification extends SystemUI {
             if (disk.isUsb()) {
                 builder.setOngoing(true);
             }
-            // Non-adoptable disks can't be snoozed.
-            if (disk.isAdoptable()) {
+            if (disk.isAdoptable() || disk.isSd()) {
                 builder.setDeleteIntent(buildSnoozeIntent(vol.getFsUuid()));
             }
 


### PR DESCRIPTION
FBE devices usually don't support adoptable therefore resulting
in SD notification popping up every boot which may be quite annoying.

This (kinda) reverts commit b138cb2c0df9e35d2f7683d529a67f8d8b64133c.

Change-Id: I4c76d05c6950b4f605450a034c1d76773f003e77